### PR TITLE
Fix: SQLite migration syntax error in m006

### DIFF
--- a/migrations.py
+++ b/migrations.py
@@ -169,12 +169,12 @@ async def m006_add_extra_fields(db):
     """
     # Add canceled and 'extra' columns to events table
     await db.execute(
-        """
-        ALTER TABLE events.events
-        ADD COLUMN canceled BOOLEAN NOT NULL DEFAULT FALSE,
-        ADD COLUMN extra TEXT;
-        """
+        "ALTER TABLE events.events ADD COLUMN canceled BOOLEAN NOT NULL DEFAULT FALSE;"
     )
+    await db.execute(
+        "ALTER TABLE events.events ADD COLUMN extra TEXT;"
+    )
+
 
     # Add 'extra' column to ticket table
     await db.execute("ALTER TABLE events.ticket ADD COLUMN extra TEXT;")


### PR DESCRIPTION
Ran into this issue on my lnbits 1.4 on NixOS using the flake with SQLite

- Fix m006_add_extra_fields migration that fails on SQLite with syntax error
- Split multi-column ALTER TABLE into separate statements (SQLite doesn't support adding multiple columns in one statement)

### LNBits logs snippet

```
running migration events.6
2025-12-31 16:04:24.76 | WARNING | (sqlite3.OperationalError) near ",": syntax error
[SQL:
        ALTER TABLE events.events
        ADD COLUMN canceled BOOLEAN NOT NULL DEFAULT FALSE,
        ADD COLUMN extra TEXT;
        ]
(Background on this error at: https://sqlalche.me/e/14/e3q8)
```