### PR TITLE
feat: NIP-52 Nostr publishing, approval workflow, and event proposals

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -22,6 +22,11 @@ events_static_files = [
 
 scheduled_tasks: list[asyncio.Task] = []
 
+# Module-level NostrClient — None when nostrclient is unavailable. Set by the
+# bootstrap task in events_start() and read via dynamic attribute lookup
+# from nostr_hooks.publish_or_delete_nostr_event.
+nostr_client = None
+
 
 def events_stop():
     for task in scheduled_tasks:
@@ -30,12 +35,50 @@ def events_stop():
         except Exception as ex:
             logger.warning(ex)
 
+    global nostr_client
+    if nostr_client:
+        asyncio.get_event_loop().create_task(nostr_client.stop())
+
 
 def events_start():
     from lnbits.tasks import create_permanent_unique_task
 
-    task = create_permanent_unique_task("ext_events", wait_for_paid_invoices)
-    scheduled_tasks.append(task)
+    task1 = create_permanent_unique_task("ext_events", wait_for_paid_invoices)
+    scheduled_tasks.append(task1)
+
+    async def _start_nostr_client():
+        global nostr_client
+        await asyncio.sleep(10)  # Wait for nostrclient to be ready
+        try:
+            from .nostr.nostr_client import NostrClient
+
+            nostr_client = NostrClient()
+            logger.info("[EVENTS] Starting NostrClient for NIP-52 sync")
+            await nostr_client.run_forever()
+        except Exception as exc:
+            logger.warning(f"[EVENTS] NostrClient failed to start: {exc}")
+            logger.info("[EVENTS] Events will work without Nostr sync")
+
+    task2 = create_permanent_unique_task("ext_events_nostr", _start_nostr_client)
+    scheduled_tasks.append(task2)
+
+    async def _sync_nostr_events():
+        global nostr_client
+        await asyncio.sleep(15)  # Wait for NostrClient to connect
+        if not nostr_client:
+            logger.info("[EVENTS] No NostrClient, skipping Nostr sync")
+            return
+        try:
+            from .nostr_sync import wait_for_nostr_events
+
+            await wait_for_nostr_events(nostr_client)
+        except Exception as exc:
+            logger.error(f"[EVENTS] Nostr sync task failed: {exc}")
+
+    task3 = create_permanent_unique_task(
+        "ext_events_nostr_sync", _sync_nostr_events
+    )
+    scheduled_tasks.append(task3)
 
 
 __all__ = ["db", "events_ext", "events_start", "events_static_files", "events_stop"]

--- a/__init__.py
+++ b/__init__.py
@@ -75,9 +75,7 @@ def events_start():
         except Exception as exc:
             logger.error(f"[EVENTS] Nostr sync task failed: {exc}")
 
-    task3 = create_permanent_unique_task(
-        "ext_events_nostr_sync", _sync_nostr_events
-    )
+    task3 = create_permanent_unique_task("ext_events_nostr_sync", _sync_nostr_events)
     scheduled_tasks.append(task3)
 
 

--- a/crud.py
+++ b/crud.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 from lnbits.db import Database
 from lnbits.helpers import urlsafe_short_hash
 
-from .models import CreateEvent, Event, Ticket, TicketExtra
+from .models import CreateEvent, Event, EventsSettings, Ticket, TicketExtra
 
 db = Database("ext_events")
 
@@ -143,6 +143,11 @@ async def purge_unpaid_tickets(event_id: str) -> None:
 
 async def create_event(data: CreateEvent) -> Event:
     event_id = urlsafe_short_hash()
+    # Default end_date to start_date and closing_date to end_date when omitted.
+    if not data.event_end_date:
+        data.event_end_date = data.event_start_date
+    if not data.closing_date:
+        data.closing_date = data.event_end_date
     event = Event(id=event_id, time=datetime.now(timezone.utc), **data.dict())
     await db.insert("events.events", event)
     return event
@@ -169,6 +174,50 @@ async def get_events(wallet_ids: str | list[str]) -> list[Event]:
         f"SELECT * FROM events.events WHERE wallet IN ({q})",
         model=Event,
     )
+
+
+async def get_all_events() -> list[Event]:
+    """All events, no wallet filter. Admin-only callers."""
+    return await db.fetchall(
+        "SELECT * FROM events.events ORDER BY time DESC",
+        model=Event,
+    )
+
+
+async def get_public_events() -> list[Event]:
+    """Approved, non-canceled events for the public listing."""
+    return await db.fetchall(
+        """
+        SELECT * FROM events.events
+        WHERE status = 'approved' AND canceled = FALSE
+        ORDER BY event_start_date ASC
+        """,
+        model=Event,
+    )
+
+
+async def get_pending_events() -> list[Event]:
+    """Proposed events awaiting admin approval."""
+    return await db.fetchall(
+        "SELECT * FROM events.events WHERE status = 'proposed' ORDER BY time DESC",
+        model=Event,
+    )
+
+
+async def get_settings() -> EventsSettings:
+    """Singleton settings row, seeded by m010."""
+    row = await db.fetchone("SELECT * FROM events.settings WHERE id = 1")
+    if row:
+        return EventsSettings(**dict(row))
+    return EventsSettings()
+
+
+async def update_settings(settings: EventsSettings) -> EventsSettings:
+    await db.execute(
+        "UPDATE events.settings SET auto_approve = :auto_approve WHERE id = 1",
+        {"auto_approve": settings.auto_approve},
+    )
+    return settings
 
 
 async def delete_event(event_id: str) -> None:

--- a/crud.py
+++ b/crud.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timedelta, timezone
 
 from lnbits.db import Database
@@ -8,47 +9,115 @@ from .models import CreateEvent, Event, Ticket, TicketExtra
 db = Database("ext_events")
 
 
+def _parse_ticket_row(row) -> dict:
+    """Normalize a ticket row before constructing a Ticket model.
+
+    - Empty-string sentinels in name/email (used because the DB columns are
+      NOT NULL but the Pydantic field is Optional when user_id is set) are
+      converted back to None.
+    - The `extra` JSON column may come back as a string when the row is
+      fetched without a model= argument; parse it so Pydantic can build
+      TicketExtra from a dict.
+    """
+    ticket_data = dict(row)
+
+    if ticket_data.get("name") == "":
+        ticket_data["name"] = None
+    if ticket_data.get("email") == "":
+        ticket_data["email"] = None
+
+    extra = ticket_data.get("extra")
+    if isinstance(extra, str):
+        ticket_data["extra"] = json.loads(extra) if extra else {}
+
+    return ticket_data
+
+
 async def create_ticket(
-    payment_hash: str, wallet: str, event: str, name: str, email: str, extra: dict
+    payment_hash: str,
+    wallet: str,
+    event: str,
+    name: str | None = None,
+    email: str | None = None,
+    user_id: str | None = None,
+    extra: dict | None = None,
 ) -> Ticket:
     now = datetime.now(timezone.utc)
-    ticket = Ticket(
+
+    # name/email columns are NOT NULL in the schema, so we store "" when only
+    # user_id is supplied. _parse_ticket_row reverses this on read.
+    if user_id:
+        db_name = ""
+        db_email = ""
+    else:
+        db_name = name or ""
+        db_email = email or ""
+
+    db_ticket = Ticket(
         id=payment_hash,
         wallet=wallet,
         event=event,
-        name=name,
-        email=email,
+        name=db_name,
+        email=db_email,
+        user_id=user_id,
         registered=False,
         paid=False,
         reg_timestamp=now,
         time=now,
         extra=TicketExtra(**extra) if extra else TicketExtra(),
     )
-    await db.insert("events.ticket", ticket)
-    return ticket
+    await db.insert("events.ticket", db_ticket)
+
+    return Ticket(
+        id=payment_hash,
+        wallet=wallet,
+        event=event,
+        name=name,
+        email=email,
+        user_id=user_id,
+        registered=False,
+        paid=False,
+        reg_timestamp=now,
+        time=now,
+        extra=TicketExtra(**extra) if extra else TicketExtra(),
+    )
 
 
 async def update_ticket(ticket: Ticket) -> Ticket:
-    await db.update("events.ticket", ticket)
+    ticket_dict = ticket.dict()
+    if ticket_dict.get("name") is None:
+        ticket_dict["name"] = ""
+    if ticket_dict.get("email") is None:
+        ticket_dict["email"] = ""
+    await db.update("events.ticket", Ticket(**ticket_dict))
     return ticket
 
 
 async def get_ticket(payment_hash: str) -> Ticket | None:
-    return await db.fetchone(
+    row = await db.fetchone(
         "SELECT * FROM events.ticket WHERE id = :id",
         {"id": payment_hash},
-        Ticket,
     )
+    if not row:
+        return None
+    return Ticket(**_parse_ticket_row(row))
 
 
 async def get_tickets(wallet_ids: str | list[str]) -> list[Ticket]:
     if isinstance(wallet_ids, str):
         wallet_ids = [wallet_ids]
     q = ",".join([f"'{wallet_id}'" for wallet_id in wallet_ids])
-    return await db.fetchall(
-        f"SELECT * FROM events.ticket WHERE wallet IN ({q})",
-        model=Ticket,
+    rows = await db.fetchall(f"SELECT * FROM events.ticket WHERE wallet IN ({q})")
+    return [Ticket(**_parse_ticket_row(row)) for row in rows]
+
+
+async def get_tickets_by_user_id(user_id: str) -> list[Ticket]:
+    """All tickets owned by the given LNbits user_id."""
+    rows = await db.fetchall(
+        "SELECT * FROM events.ticket WHERE user_id = :user_id ORDER BY time DESC",
+        {"user_id": user_id},
     )
+    return [Ticket(**_parse_ticket_row(row)) for row in rows]
 
 
 async def delete_ticket(payment_hash: str) -> None:
@@ -107,8 +176,8 @@ async def delete_event(event_id: str) -> None:
 
 
 async def get_event_tickets(event_id: str) -> list[Ticket]:
-    return await db.fetchall(
+    rows = await db.fetchall(
         "SELECT * FROM events.ticket WHERE event = :event",
         {"event": event_id},
-        Ticket,
     )
+    return [Ticket(**_parse_ticket_row(row)) for row in rows]

--- a/crud.py
+++ b/crud.py
@@ -94,7 +94,7 @@ async def update_ticket(ticket: Ticket) -> Ticket:
 
 
 async def get_ticket(payment_hash: str) -> Ticket | None:
-    row = await db.fetchone(
+    row: dict | None = await db.fetchone(
         "SELECT * FROM events.ticket WHERE id = :id",
         {"id": payment_hash},
     )
@@ -107,13 +107,15 @@ async def get_tickets(wallet_ids: str | list[str]) -> list[Ticket]:
     if isinstance(wallet_ids, str):
         wallet_ids = [wallet_ids]
     q = ",".join([f"'{wallet_id}'" for wallet_id in wallet_ids])
-    rows = await db.fetchall(f"SELECT * FROM events.ticket WHERE wallet IN ({q})")
+    rows: list[dict] = await db.fetchall(
+        f"SELECT * FROM events.ticket WHERE wallet IN ({q})"
+    )
     return [Ticket(**_parse_ticket_row(row)) for row in rows]
 
 
 async def get_tickets_by_user_id(user_id: str) -> list[Ticket]:
     """All tickets owned by the given LNbits user_id."""
-    rows = await db.fetchall(
+    rows: list[dict] = await db.fetchall(
         "SELECT * FROM events.ticket WHERE user_id = :user_id ORDER BY time DESC",
         {"user_id": user_id},
     )
@@ -206,7 +208,7 @@ async def get_pending_events() -> list[Event]:
 
 async def get_settings() -> EventsSettings:
     """Singleton settings row, seeded by m010."""
-    row = await db.fetchone("SELECT * FROM events.settings WHERE id = 1")
+    row: dict | None = await db.fetchone("SELECT * FROM events.settings WHERE id = 1")
     if row:
         return EventsSettings(**dict(row))
     return EventsSettings()
@@ -225,7 +227,7 @@ async def delete_event(event_id: str) -> None:
 
 
 async def get_event_tickets(event_id: str) -> list[Ticket]:
-    rows = await db.fetchall(
+    rows: list[dict] = await db.fetchall(
         "SELECT * FROM events.ticket WHERE event = :event",
         {"event": event_id},
     )

--- a/migrations.py
+++ b/migrations.py
@@ -200,3 +200,35 @@ async def m007_add_user_id_support(db):
     await _alter_add_column_safe(
         db, "ALTER TABLE events.ticket ADD COLUMN user_id TEXT"
     )
+
+
+async def m008_add_event_status(db):
+    """
+    Add status column to events table for the proposal/approval workflow.
+    Values: 'proposed', 'approved', 'rejected'. Existing rows default to
+    'approved' so they stay visible after upgrade.
+    """
+    await _alter_add_column_safe(
+        db,
+        "ALTER TABLE events.events ADD COLUMN status TEXT NOT NULL DEFAULT 'approved'",
+    )
+
+
+async def m010_add_events_settings(db):
+    """
+    Create the extension settings singleton row used by the admin UI to
+    toggle e.g. auto_approve.
+    """
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS events.settings (
+            id INTEGER PRIMARY KEY DEFAULT 1,
+            auto_approve BOOLEAN NOT NULL DEFAULT FALSE
+        )
+        """
+    )
+    await db.execute(
+        "INSERT INTO events.settings (id, auto_approve) "
+        "SELECT 1, FALSE WHERE NOT EXISTS "
+        "(SELECT 1 FROM events.settings WHERE id = 1)"
+    )

--- a/migrations.py
+++ b/migrations.py
@@ -162,16 +162,30 @@ async def m005_add_image_banner(db):
     await db.execute("ALTER TABLE events.events ADD COLUMN banner TEXT;")
 
 
+async def _alter_add_column_safe(db, sql: str) -> None:
+    """ALTER TABLE ADD COLUMN that swallows duplicate-column errors.
+
+    Earlier aiolabs/events forks added some of these columns under different
+    migration names (e.g. our former m007). Skipping the error keeps the
+    migration log monotonic for both fresh installs and pre-rebase upgrades.
+    """
+    try:
+        await db.execute(sql)
+    except Exception as exc:
+        msg = str(exc).lower()
+        if "duplicate column" in msg or "already exists" in msg:
+            return
+        raise
+
+
 async def m006_add_extra_fields(db):
     """
     Add a canceled and 'extra' column to events and ticket tables
     to support promo codes and ticket metadata.
     """
-    # Add canceled and 'extra' columns to events table
-    await db.execute(
-        "ALTER TABLE events.events ADD COLUMN canceled BOOLEAN NOT NULL DEFAULT FALSE;"
+    await _alter_add_column_safe(
+        db,
+        "ALTER TABLE events.events ADD COLUMN canceled BOOLEAN NOT NULL DEFAULT FALSE",
     )
-    await db.execute("ALTER TABLE events.events ADD COLUMN extra TEXT;")
-
-    # Add 'extra' column to ticket table
-    await db.execute("ALTER TABLE events.ticket ADD COLUMN extra TEXT;")
+    await _alter_add_column_safe(db, "ALTER TABLE events.events ADD COLUMN extra TEXT")
+    await _alter_add_column_safe(db, "ALTER TABLE events.ticket ADD COLUMN extra TEXT")

--- a/migrations.py
+++ b/migrations.py
@@ -232,14 +232,12 @@ async def m010_add_events_settings(db):
     Create the extension settings singleton row used by the admin UI to
     toggle e.g. auto_approve.
     """
-    await db.execute(
-        """
+    await db.execute("""
         CREATE TABLE IF NOT EXISTS events.settings (
             id INTEGER PRIMARY KEY DEFAULT 1,
             auto_approve BOOLEAN NOT NULL DEFAULT FALSE
         )
-        """
-    )
+        """)
     await db.execute(
         "INSERT INTO events.settings (id, auto_approve) "
         "SELECT 1, FALSE WHERE NOT EXISTS "

--- a/migrations.py
+++ b/migrations.py
@@ -189,3 +189,14 @@ async def m006_add_extra_fields(db):
     )
     await _alter_add_column_safe(db, "ALTER TABLE events.events ADD COLUMN extra TEXT")
     await _alter_add_column_safe(db, "ALTER TABLE events.ticket ADD COLUMN extra TEXT")
+
+
+async def m007_add_user_id_support(db):
+    """
+    Add user_id column to ticket table so a ticket can reference an LNbits
+    user id instead of (name, email). Application logic enforces that exactly
+    one identifier scheme is used per ticket.
+    """
+    await _alter_add_column_safe(
+        db, "ALTER TABLE events.ticket ADD COLUMN user_id TEXT"
+    )

--- a/migrations.py
+++ b/migrations.py
@@ -214,6 +214,19 @@ async def m008_add_event_status(db):
     )
 
 
+async def m009_add_nostr_columns(db):
+    """
+    Track the most recent NIP-52 calendar event we published for this event
+    (used for replaceable updates and NIP-09 deletes).
+    """
+    await _alter_add_column_safe(
+        db, "ALTER TABLE events.events ADD COLUMN nostr_event_id TEXT"
+    )
+    await _alter_add_column_safe(
+        db, "ALTER TABLE events.events ADD COLUMN nostr_event_created_at INTEGER"
+    )
+
+
 async def m010_add_events_settings(db):
     """
     Create the extension settings singleton row used by the admin UI to
@@ -231,4 +244,16 @@ async def m010_add_events_settings(db):
         "INSERT INTO events.settings (id, auto_approve) "
         "SELECT 1, FALSE WHERE NOT EXISTS "
         "(SELECT 1 FROM events.settings WHERE id = 1)"
+    )
+
+
+async def m011_add_location_and_categories(db):
+    """
+    Add NIP-52 calendar metadata (location and a JSON-encoded category list).
+    """
+    await _alter_add_column_safe(
+        db, "ALTER TABLE events.events ADD COLUMN location TEXT"
+    )
+    await _alter_add_column_safe(
+        db, "ALTER TABLE events.events ADD COLUMN categories TEXT"
     )

--- a/models.py
+++ b/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from fastapi import Query
-from pydantic import BaseModel, EmailStr, Field, validator
+from pydantic import BaseModel, EmailStr, Field, root_validator, validator
 
 
 class PromoCode(BaseModel):
@@ -77,18 +77,33 @@ class TicketExtra(BaseModel):
 
 
 class CreateTicket(BaseModel):
-    name: str
-    email: EmailStr
+    name: str | None = None
+    email: EmailStr | None = None
+    user_id: str | None = None  # LNbits user id (alternative to name+email)
     promo_code: str | None = None
     refund_address: str | None = None
+
+    @root_validator
+    def validate_identifiers(cls, values):
+        name = values.get("name")
+        email = values.get("email")
+        user_id = values.get("user_id")
+        if not user_id and not (name and email):
+            raise ValueError(
+                "Either user_id or both name and email must be provided"
+            )
+        if user_id and (name or email):
+            raise ValueError("Cannot provide both user_id and name/email")
+        return values
 
 
 class Ticket(BaseModel):
     id: str
     wallet: str
     event: str
-    name: str
-    email: str
+    name: str | None = None
+    email: str | None = None
+    user_id: str | None = None
     registered: bool
     paid: bool
     time: datetime
@@ -98,7 +113,7 @@ class Ticket(BaseModel):
 
 class PublicTicket(BaseModel):
     event: str
-    name: str
+    name: str | None = None
     registered: bool
     paid: bool
     time: datetime

--- a/models.py
+++ b/models.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-from fastapi import Query
 from pydantic import BaseModel, EmailStr, Field, root_validator, validator
 
 
@@ -27,46 +26,55 @@ class EventExtra(BaseModel):
 
 
 class CreateEvent(BaseModel):
-    wallet: str
-    name: str
-    info: str
-    closing_date: str
-    event_start_date: str
-    event_end_date: str
+    wallet: str | None = None  # filled from caller's wallet if absent
+    name: str  # title (required)
+    info: str = ""  # description (optional)
+    closing_date: str | None = None  # defaults to event_end_date
+    event_start_date: str  # required
+    event_end_date: str | None = None  # defaults to event_start_date
     currency: str = "sat"
-    amount_tickets: int = Query(..., ge=0)
-    price_per_ticket: float = Query(..., ge=0)
+    amount_tickets: int = 0  # 0 = unlimited / not ticketed
+    price_per_ticket: float = 0  # 0 = free
     banner: str | None = None
     extra: EventExtra = Field(default_factory=EventExtra)
+    status: str = "approved"  # proposed, approved, rejected
 
 
 class Event(BaseModel):
     id: str
     wallet: str
     name: str
-    info: str
-    closing_date: str
+    info: str = ""
+    closing_date: str | None = None
     canceled: bool = False
     event_start_date: str
-    event_end_date: str
-    currency: str
-    amount_tickets: int
-    price_per_ticket: float
+    event_end_date: str | None = None
+    currency: str = "sat"
+    amount_tickets: int = 0
+    price_per_ticket: float = 0
     time: datetime
     sold: int = 0
     banner: str | None = None
     extra: EventExtra = Field(default_factory=EventExtra)
+    status: str = "approved"
 
 
 class PublicEvent(BaseModel):
     id: str
     name: str
     info: str
-    closing_date: str
+    closing_date: str | None = None
     canceled: bool
     event_start_date: str
-    event_end_date: str
+    event_end_date: str | None = None
     banner: str | None
+    status: str = "approved"  # surfaces "proposed"/"rejected" so SFC can render banner
+
+
+class EventsSettings(BaseModel):
+    """Extension-level settings for the events extension."""
+
+    auto_approve: bool = False  # Skip approval workflow for non-admin users
 
 
 class TicketExtra(BaseModel):

--- a/models.py
+++ b/models.py
@@ -118,9 +118,7 @@ class CreateTicket(BaseModel):
         email = values.get("email")
         user_id = values.get("user_id")
         if not user_id and not (name and email):
-            raise ValueError(
-                "Either user_id or both name and email must be provided"
-            )
+            raise ValueError("Either user_id or both name and email must be provided")
         if user_id and (name or email):
             raise ValueError("Cannot provide both user_id and name/email")
         return values

--- a/models.py
+++ b/models.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 
 from pydantic import BaseModel, EmailStr, Field, root_validator, validator
@@ -36,6 +37,8 @@ class CreateEvent(BaseModel):
     amount_tickets: int = 0  # 0 = unlimited / not ticketed
     price_per_ticket: float = 0  # 0 = free
     banner: str | None = None
+    location: str | None = None  # venue/address (NIP-52 'location' tag)
+    categories: list[str] = Field(default_factory=list)  # NIP-52 't' tags
     extra: EventExtra = Field(default_factory=EventExtra)
     status: str = "approved"  # proposed, approved, rejected
 
@@ -55,8 +58,18 @@ class Event(BaseModel):
     time: datetime
     sold: int = 0
     banner: str | None = None
+    location: str | None = None
+    categories: list[str] = Field(default_factory=list)
     extra: EventExtra = Field(default_factory=EventExtra)
     status: str = "approved"
+    nostr_event_id: str | None = None
+    nostr_event_created_at: int | None = None
+
+    @validator("categories", pre=True)
+    def parse_categories(cls, v):
+        if isinstance(v, str):
+            return json.loads(v) if v else []
+        return v or []
 
 
 class PublicEvent(BaseModel):
@@ -68,7 +81,15 @@ class PublicEvent(BaseModel):
     event_start_date: str
     event_end_date: str | None = None
     banner: str | None
+    location: str | None = None
+    categories: list[str] = Field(default_factory=list)
     status: str = "approved"  # surfaces "proposed"/"rejected" so SFC can render banner
+
+    @validator("categories", pre=True)
+    def parse_categories(cls, v):
+        if isinstance(v, str):
+            return json.loads(v) if v else []
+        return v or []
 
 
 class EventsSettings(BaseModel):

--- a/nostr/event.py
+++ b/nostr/event.py
@@ -1,0 +1,26 @@
+import hashlib
+import json
+
+from pydantic import BaseModel
+
+
+class NostrEvent(BaseModel):
+    id: str = ""
+    pubkey: str
+    created_at: int
+    kind: int
+    tags: list[list[str]] = []
+    content: str = ""
+    sig: str | None = None
+
+    def serialize(self) -> list:
+        return [0, self.pubkey, self.created_at, self.kind, self.tags, self.content]
+
+    def serialize_json(self) -> str:
+        e = self.serialize()
+        return json.dumps(e, separators=(",", ":"), ensure_ascii=False)
+
+    @property
+    def event_id(self) -> str:
+        data = self.serialize_json()
+        return hashlib.sha256(data.encode()).hexdigest()

--- a/nostr/nostr_client.py
+++ b/nostr/nostr_client.py
@@ -1,0 +1,142 @@
+"""
+Bidirectional Nostr client for the events extension.
+
+Connects to the nostrclient extension's internal WebSocket to publish
+and subscribe to NIP-52 calendar events. Based on nostrmarket's
+NostrClient pattern.
+"""
+
+import asyncio
+import json
+from asyncio import Queue
+from collections import OrderedDict
+
+from lnbits.helpers import encrypt_internal_message, urlsafe_short_hash
+from lnbits.settings import settings
+from loguru import logger
+from websocket import WebSocketApp
+
+from .event import NostrEvent
+
+MAX_SEEN_EVENTS = 500
+
+
+class NostrClient:
+    def __init__(self):
+        self.receive_event_queue: Queue = Queue()
+        self.send_req_queue: Queue = Queue()
+        self.ws: WebSocketApp | None = None
+        self.subscription_id = "events-" + urlsafe_short_hash()[:32]
+        self.running = False
+        self._seen_events: OrderedDict[str, None] = OrderedDict()
+
+    @property
+    def is_websocket_connected(self):
+        if not self.ws:
+            return False
+        return self.ws.keep_running
+
+    async def connect(self) -> WebSocketApp:
+        relay_endpoint = encrypt_internal_message("relay", urlsafe=True)
+        ws_url = (
+            f"ws://localhost:{settings.port}"
+            f"/nostrclient/api/v1/{relay_endpoint}"
+        )
+
+        logger.info("[EVENTS] Connecting to nostrclient WebSocket...")
+
+        def on_open(_):
+            logger.info("[EVENTS] Connected to nostrclient WebSocket")
+
+        def on_message(_, message):
+            try:
+                self.receive_event_queue.put_nowait(message)
+            except Exception as e:
+                logger.error(f"[EVENTS] Failed to queue message: {e}")
+
+        def on_error(_, error):
+            logger.warning(f"[EVENTS] WebSocket error: {error}")
+
+        def on_close(_, status_code, message):
+            logger.warning(
+                f"[EVENTS] WebSocket closed: {status_code} {message}"
+            )
+            self.receive_event_queue.put_nowait(
+                ValueError("WebSocket closed")
+            )
+
+        ws = WebSocketApp(
+            ws_url,
+            on_message=on_message,
+            on_open=on_open,
+            on_close=on_close,
+            on_error=on_error,
+        )
+
+        from threading import Thread
+
+        wst = Thread(target=ws.run_forever)
+        wst.daemon = True
+        wst.start()
+
+        return ws
+
+    async def run_forever(self):
+        self.running = True
+        while self.running:
+            try:
+                if not self.is_websocket_connected:
+                    self.ws = await self.connect()
+                    await asyncio.sleep(5)
+
+                req = await self.send_req_queue.get()
+                assert self.ws
+                self.ws.send(json.dumps(req))
+            except Exception as ex:
+                logger.warning(f"[EVENTS] NostrClient error: {ex}")
+                await asyncio.sleep(60)
+
+    def is_duplicate_event(self, event_id: str) -> bool:
+        """Check if an event has been seen recently."""
+        if event_id in self._seen_events:
+            return True
+        self._seen_events[event_id] = None
+        if len(self._seen_events) > MAX_SEEN_EVENTS:
+            self._seen_events.popitem(last=False)
+        return False
+
+    async def get_event(self):
+        """Get next event from the receive queue."""
+        value = await self.receive_event_queue.get()
+        if isinstance(value, ValueError):
+            raise value
+        return value
+
+    async def publish_nostr_event(self, e: NostrEvent):
+        await self.send_req_queue.put(["EVENT", e.dict()])
+
+    async def subscribe(self, filters: list[dict]):
+        """Subscribe to events matching the given filters."""
+        self.subscription_id = "events-" + urlsafe_short_hash()[:32]
+        await self.send_req_queue.put(
+            ["REQ", self.subscription_id, *filters]
+        )
+        logger.info(
+            f"[EVENTS] Subscribed to NIP-52 events "
+            f"(sub: {self.subscription_id[:20]}...)"
+        )
+
+    async def unsubscribe(self):
+        """Unsubscribe from current subscription."""
+        await self.send_req_queue.put(["CLOSE", self.subscription_id])
+
+    async def stop(self):
+        await self.unsubscribe()
+        self.running = False
+        await asyncio.sleep(2)
+        if self.ws:
+            try:
+                self.ws.close()
+            except Exception:
+                pass
+            self.ws = None

--- a/nostr/nostr_client.py
+++ b/nostr/nostr_client.py
@@ -39,8 +39,7 @@ class NostrClient:
     async def connect(self) -> WebSocketApp:
         relay_endpoint = encrypt_internal_message("relay", urlsafe=True)
         ws_url = (
-            f"ws://localhost:{settings.port}"
-            f"/nostrclient/api/v1/{relay_endpoint}"
+            f"ws://localhost:{settings.port}" f"/nostrclient/api/v1/{relay_endpoint}"
         )
 
         logger.info("[EVENTS] Connecting to nostrclient WebSocket...")
@@ -58,12 +57,8 @@ class NostrClient:
             logger.warning(f"[EVENTS] WebSocket error: {error}")
 
         def on_close(_, status_code, message):
-            logger.warning(
-                f"[EVENTS] WebSocket closed: {status_code} {message}"
-            )
-            self.receive_event_queue.put_nowait(
-                ValueError("WebSocket closed")
-            )
+            logger.warning(f"[EVENTS] WebSocket closed: {status_code} {message}")
+            self.receive_event_queue.put_nowait(ValueError("WebSocket closed"))
 
         ws = WebSocketApp(
             ws_url,
@@ -118,9 +113,7 @@ class NostrClient:
     async def subscribe(self, filters: list[dict]):
         """Subscribe to events matching the given filters."""
         self.subscription_id = "events-" + urlsafe_short_hash()[:32]
-        await self.send_req_queue.put(
-            ["REQ", self.subscription_id, *filters]
-        )
+        await self.send_req_queue.put(["REQ", self.subscription_id, *filters])
         logger.info(
             f"[EVENTS] Subscribed to NIP-52 events "
             f"(sub: {self.subscription_id[:20]}...)"

--- a/nostr_hooks.py
+++ b/nostr_hooks.py
@@ -29,11 +29,15 @@ async def publish_or_delete_nostr_event(event: Event, *, delete: bool = False) -
         if not wallet_obj:
             return
         account = await get_account(wallet_obj.user)
-        if not account or not account.pubkey or not account.prvkey:
+        if not account or not account.pubkey or not account.prvkey:  # type: ignore[attr-defined]
             return
 
         nostr_event = await publish_event_to_nostr(
-            nostr_client, event, account.pubkey, account.prvkey, delete=delete
+            nostr_client,
+            event,
+            account.pubkey,
+            account.prvkey,  # type: ignore[attr-defined]
+            delete=delete,
         )
         if nostr_event and not delete:
             event.nostr_event_id = nostr_event.id

--- a/nostr_hooks.py
+++ b/nostr_hooks.py
@@ -1,0 +1,43 @@
+"""Helpers that bridge event-mutation handlers to the Nostr publisher.
+
+Lives in its own module so both `events_api_router` and any future router
+can call it without importing through `views_api`, which would create an
+import cycle (views_api -> nostr_hooks -> nostr_publisher -> models).
+"""
+
+from loguru import logger
+
+from .crud import update_event
+from .models import Event
+from .nostr_publisher import publish_event_to_nostr
+
+
+async def publish_or_delete_nostr_event(event: Event, *, delete: bool = False) -> None:
+    """Publish or delete the NIP-52 calendar event for `event`.
+
+    Pulls the wallet owner's pubkey/prvkey to sign with the user's identity.
+    Failures are logged and swallowed so a Nostr outage doesn't break the
+    HTTP flow that triggered the publish.
+    """
+    try:
+        from lnbits.core.crud.users import get_account
+        from lnbits.core.crud.wallets import get_wallet
+
+        from . import nostr_client
+
+        wallet_obj = await get_wallet(event.wallet)
+        if not wallet_obj:
+            return
+        account = await get_account(wallet_obj.user)
+        if not account or not account.pubkey or not account.prvkey:
+            return
+
+        nostr_event = await publish_event_to_nostr(
+            nostr_client, event, account.pubkey, account.prvkey, delete=delete
+        )
+        if nostr_event and not delete:
+            event.nostr_event_id = nostr_event.id
+            event.nostr_event_created_at = nostr_event.created_at
+            await update_event(event)
+    except Exception as exc:
+        logger.warning(f"[EVENTS] Nostr publish failed: {exc}")

--- a/nostr_publisher.py
+++ b/nostr_publisher.py
@@ -41,7 +41,7 @@ def build_nip52_event(event: Event, pubkey: str) -> NostrEvent:
         tags.append(["image", event.banner])
     if event.location:
         tags.append(["location", event.location])
-    for cat in (event.categories or []):
+    for cat in event.categories or []:
         tags.append(["t", cat])
 
     nostr_event = NostrEvent(

--- a/nostr_publisher.py
+++ b/nostr_publisher.py
@@ -1,0 +1,118 @@
+"""
+NIP-52 calendar event publishing for the events extension.
+
+Builds kind 31922 (date-based) calendar events from the Event model,
+signs them with the event creator's Account keypair, and publishes
+via the NostrClient to nostrclient relays.
+
+Reference: https://github.com/nostr-protocol/nips/blob/master/52.md
+"""
+
+import time
+
+import coincurve
+from loguru import logger
+
+from .models import Event
+from .nostr.event import NostrEvent
+
+
+def build_nip52_event(event: Event, pubkey: str) -> NostrEvent:
+    """
+    Convert an Event model to a NIP-52 kind 31922 (date-based) calendar event.
+
+    Tags:
+      d       - event.id (addressable identifier)
+      title   - event.name
+      start   - event.event_start_date (ISO date string)
+      end     - event.event_end_date (optional)
+      image   - event.banner (optional)
+    Content:  event.info (description)
+    """
+    tags = [
+        ["d", event.id],
+        ["title", event.name],
+        ["start", event.event_start_date],
+    ]
+
+    if event.event_end_date:
+        tags.append(["end", event.event_end_date])
+    if event.banner:
+        tags.append(["image", event.banner])
+    if event.location:
+        tags.append(["location", event.location])
+    for cat in (event.categories or []):
+        tags.append(["t", cat])
+
+    nostr_event = NostrEvent(
+        pubkey=pubkey,
+        created_at=int(time.time()),
+        kind=31922,
+        tags=tags,
+        content=event.info or "",
+    )
+    nostr_event.id = nostr_event.event_id
+    return nostr_event
+
+
+def build_nip52_delete_event(event: Event, pubkey: str) -> NostrEvent:
+    """
+    Build a kind 5 delete event for a published NIP-52 calendar event.
+
+    Uses an 'a' tag to reference the parameterized replaceable event
+    (kind 31922) per NIP-09.
+    """
+    nostr_event = NostrEvent(
+        pubkey=pubkey,
+        created_at=int(time.time()),
+        kind=5,
+        tags=[
+            ["a", f"31922:{pubkey}:{event.id}"],
+        ],
+        content="Event canceled",
+    )
+    nostr_event.id = nostr_event.event_id
+    return nostr_event
+
+
+def sign_nostr_event(nostr_event: NostrEvent, private_key_hex: str) -> None:
+    """Sign a NostrEvent in-place using Schnorr signature."""
+    privkey = coincurve.PrivateKey(bytes.fromhex(private_key_hex))
+    sig = privkey.sign_schnorr(bytes.fromhex(nostr_event.id))
+    nostr_event.sig = sig.hex()
+
+
+async def publish_event_to_nostr(
+    nostr_client,
+    event: Event,
+    account_pubkey: str,
+    account_prvkey: str,
+    delete: bool = False,
+) -> NostrEvent | None:
+    """
+    Build, sign, and publish a NIP-52 calendar event (or delete event).
+
+    Returns the published NostrEvent for metadata storage, or None on failure.
+    """
+    if not nostr_client:
+        logger.debug("[EVENTS] No NostrClient available, skipping publish")
+        return None
+
+    try:
+        if delete:
+            nostr_event = build_nip52_delete_event(event, account_pubkey)
+        else:
+            nostr_event = build_nip52_event(event, account_pubkey)
+
+        sign_nostr_event(nostr_event, account_prvkey)
+        await nostr_client.publish_nostr_event(nostr_event)
+
+        logger.info(
+            f"[EVENTS] Published NIP-52 {'delete' if delete else 'calendar'} "
+            f"event: {nostr_event.id[:16]}... (kind {nostr_event.kind})"
+        )
+        return nostr_event
+
+    except Exception as e:
+        logger.warning(f"[EVENTS] Failed to publish to Nostr: {e}")
+        return None

--- a/nostr_sync.py
+++ b/nostr_sync.py
@@ -1,0 +1,155 @@
+"""
+Bidirectional Nostr sync for the events extension.
+
+Subscribes to NIP-52 calendar events (kind 31922/31923) from relays
+and upserts them into the local database. Enables federated event
+discovery — events published by other LNbits instances or Nostr
+clients appear in the local events listing.
+"""
+
+import asyncio
+import json
+from datetime import datetime, timezone
+
+from loguru import logger
+
+from .crud import db, get_event, update_event
+from .models import Event
+from .nostr.nostr_client import NostrClient
+
+
+async def process_nostr_message(nostr_client: NostrClient, message: str):
+    """Process an incoming Nostr relay message."""
+    try:
+        data = json.loads(message)
+    except json.JSONDecodeError:
+        return
+
+    if not isinstance(data, list) or len(data) < 2:
+        return
+
+    msg_type = data[0]
+
+    if msg_type == "EVENT" and len(data) >= 3:
+        event_data = data[2]
+        await _handle_calendar_event(nostr_client, event_data)
+    elif msg_type == "EOSE":
+        logger.debug("[EVENTS] End of stored events from relay")
+    elif msg_type == "NOTICE":
+        logger.info(f"[EVENTS] Relay notice: {data[1]}")
+
+
+async def _handle_calendar_event(nostr_client: NostrClient, event_data: dict):
+    """Handle an incoming NIP-52 calendar event (kind 31922 or 31923)."""
+    kind = event_data.get("kind")
+    if kind not in (31922, 31923):
+        return
+
+    event_id = event_data.get("id", "")
+    if nostr_client.is_duplicate_event(event_id):
+        return
+
+    tags = {t[0]: t[1] for t in event_data.get("tags", []) if len(t) >= 2}
+    tag_lists = {}
+    for t in event_data.get("tags", []):
+        if len(t) >= 2:
+            tag_lists.setdefault(t[0], []).append(t[1])
+
+    d_tag = tags.get("d")
+    if not d_tag:
+        return
+
+    title = tags.get("title", "Untitled Event")
+    start = tags.get("start")
+    if not start:
+        return
+
+    end = tags.get("end")
+    description = event_data.get("content", "")
+    image = tags.get("image")
+    location = tags.get("location")
+    categories = tag_lists.get("t", [])
+
+    # Check if we already have this event (by d-tag as our event ID
+    # or by nostr_event_id)
+    existing = await get_event(d_tag)
+    if not existing:
+        # Check by nostr_event_id
+        existing = await db.fetchone(
+            "SELECT * FROM events.events WHERE nostr_event_id = :nid",
+            {"nid": event_id},
+            Event,
+        )
+
+    if existing:
+        # Update if the incoming event is newer
+        incoming_created_at = event_data.get("created_at", 0)
+        if (
+            existing.nostr_event_created_at
+            and incoming_created_at <= existing.nostr_event_created_at
+        ):
+            return  # We already have a newer version
+
+        existing.name = title
+        existing.info = description
+        existing.event_start_date = start
+        existing.event_end_date = end
+        existing.banner = image
+        existing.location = location
+        existing.categories = categories
+        existing.nostr_event_id = event_id
+        existing.nostr_event_created_at = incoming_created_at
+        await update_event(existing)
+        logger.info(f"[EVENTS] Updated event from Nostr: {title}")
+    else:
+        # Create new event from Nostr — discovered events are auto-approved
+        # (they're already public on relays). Use the d-tag as the event ID
+        # for replaceable-event correlation.
+        new_event = Event(
+            id=d_tag,
+            wallet="",
+            name=title,
+            info=description,
+            event_start_date=start,
+            event_end_date=end,
+            banner=image,
+            location=location,
+            categories=categories,
+            status="approved",
+            time=datetime.now(timezone.utc),
+            nostr_event_id=event_id,
+            nostr_event_created_at=event_data.get("created_at", 0),
+        )
+        try:
+            await db.insert("events.events", new_event)
+            logger.info(f"[EVENTS] Discovered event from Nostr: {title}")
+        except Exception as e:
+            # Likely duplicate key — skip
+            logger.debug(f"[EVENTS] Skipped duplicate event: {e}")
+
+
+async def wait_for_nostr_events(nostr_client: NostrClient):
+    """
+    Background task: subscribe to NIP-52 events and process them.
+    """
+    logger.info("[EVENTS] Starting Nostr event sync...")
+
+    while True:
+        try:
+            # Subscribe to NIP-52 calendar events
+            await nostr_client.subscribe([
+                {"kinds": [31922, 31923]},
+            ])
+
+            # Process incoming events
+            while True:
+                message = await nostr_client.get_event()
+                await process_nostr_message(nostr_client, message)
+
+        except ValueError:
+            # WebSocket closed — will reconnect
+            logger.warning("[EVENTS] Nostr connection lost, resubscribing...")
+            await asyncio.sleep(10)
+        except Exception as e:
+            logger.error(f"[EVENTS] Nostr sync error: {e}")
+            await asyncio.sleep(30)

--- a/nostr_sync.py
+++ b/nostr_sync.py
@@ -50,7 +50,7 @@ async def _handle_calendar_event(nostr_client: NostrClient, event_data: dict):
         return
 
     tags = {t[0]: t[1] for t in event_data.get("tags", []) if len(t) >= 2}
-    tag_lists = {}
+    tag_lists: dict[str, list[str]] = {}
     for t in event_data.get("tags", []):
         if len(t) >= 2:
             tag_lists.setdefault(t[0], []).append(t[1])
@@ -137,9 +137,11 @@ async def wait_for_nostr_events(nostr_client: NostrClient):
     while True:
         try:
             # Subscribe to NIP-52 calendar events
-            await nostr_client.subscribe([
-                {"kinds": [31922, 31923]},
-            ])
+            await nostr_client.subscribe(
+                [
+                    {"kinds": [31922, 31923]},
+                ]
+            )
 
             # Process incoming events
             while True:

--- a/static/js/display.vue
+++ b/static/js/display.vue
@@ -12,7 +12,32 @@
           <div v-html="event.info" class="q-pa-lg"></div>
         </q-card-section>
       </q-card>
-      <q-card class="q-pa-lg">
+
+      <q-banner
+        v-if="event.status === 'proposed'"
+        class="bg-orange-2 text-orange-10"
+        rounded
+      >
+        <template v-slot:avatar>
+          <q-icon name="pending" color="orange-10"></q-icon>
+        </template>
+        <span class="text-weight-medium">Pending approval</span> &mdash; this
+        event is awaiting an admin review and is not yet open for tickets.
+      </q-banner>
+
+      <q-banner
+        v-else-if="event.status === 'rejected'"
+        class="bg-red-2 text-red-10"
+        rounded
+      >
+        <template v-slot:avatar>
+          <q-icon name="block" color="red-10"></q-icon>
+        </template>
+        <span class="text-weight-medium">Not approved</span> &mdash; this event
+        was reviewed and is not being published.
+      </q-banner>
+
+      <q-card v-if="event.status === 'approved'" class="q-pa-lg">
         <q-card-section class="q-pa-none">
           <h5 class="q-mt-none">Buy Ticket</h5>
           <q-form @submit="createInvoice()" class="q-gutter-md">

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -187,12 +187,7 @@ window.PageEvents = {
     },
     saveSettings() {
       LNbits.api
-        .request(
-          'PUT',
-          '/events/api/v1/events/settings',
-          null,
-          this.settings
-        )
+        .request('PUT', '/events/api/v1/events/settings', null, this.settings)
         .then(() => {
           Quasar.Notify.create({type: 'positive', message: 'Settings saved'})
         })

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -5,6 +5,12 @@ window.PageEvents = {
       events: [],
       tickets: [],
       currencies: [],
+      pendingEvents: [],
+      allUserEvents: [],
+      isAdmin: false,
+      settings: {
+        auto_approve: false
+      },
       eventsTable: {
         columns: [
           {name: 'id', align: 'left', label: 'ID', field: 'id'},
@@ -65,7 +71,8 @@ window.PageEvents = {
             field: 'sold'
           },
           {name: 'info', align: 'left', label: 'Info', field: 'info'},
-          {name: 'banner', align: 'left', label: 'Banner', field: 'banner'}
+          {name: 'banner', align: 'left', label: 'Banner', field: 'banner'},
+          {name: 'status', align: 'left', label: 'Status', field: 'status'}
         ],
         pagination: {
           rowsPerPage: 10
@@ -152,6 +159,84 @@ window.PageEvents = {
           this.events = response.data
           this.checkCanceledEvents()
         })
+
+      // Admin probe: a 200 from /all means we're an LNbits admin.
+      LNbits.api
+        .request('GET', '/events/api/v1/events/all')
+        .then(response => {
+          this.isAdmin = true
+          const ownWalletIds = this.g.user.wallets.map(w => w.id)
+          this.allUserEvents = response.data.filter(
+            e => !ownWalletIds.includes(e.wallet)
+          )
+        })
+        .catch(() => {
+          this.isAdmin = false
+          this.allUserEvents = []
+        })
+    },
+    getSettings() {
+      LNbits.api
+        .request('GET', '/events/api/v1/events/settings')
+        .then(response => {
+          this.settings = response.data
+        })
+        .catch(() => {
+          // Not admin or settings unavailable; keep defaults.
+        })
+    },
+    saveSettings() {
+      LNbits.api
+        .request(
+          'PUT',
+          '/events/api/v1/events/settings',
+          null,
+          this.settings
+        )
+        .then(() => {
+          Quasar.Notify.create({type: 'positive', message: 'Settings saved'})
+        })
+        .catch(LNbits.utils.notifyApiError)
+    },
+    getPendingEvents() {
+      LNbits.api
+        .request('GET', '/events/api/v1/events/pending')
+        .then(response => {
+          this.pendingEvents = response.data
+        })
+        .catch(() => {
+          this.pendingEvents = []
+        })
+    },
+    approveEvent(eventId) {
+      LNbits.utils.confirmDialog('Approve this event?').onOk(() => {
+        LNbits.api
+          .request('PUT', '/events/api/v1/events/' + eventId + '/approve')
+          .then(() => {
+            Quasar.Notify.create({
+              type: 'positive',
+              message: 'Event approved'
+            })
+            this.getEvents()
+            this.getPendingEvents()
+          })
+          .catch(LNbits.utils.notifyApiError)
+      })
+    },
+    rejectEvent(eventId) {
+      LNbits.utils.confirmDialog('Reject this event?').onOk(() => {
+        LNbits.api
+          .request('PUT', '/events/api/v1/events/' + eventId + '/reject')
+          .then(() => {
+            Quasar.Notify.create({
+              type: 'positive',
+              message: 'Event rejected'
+            })
+            this.getEvents()
+            this.getPendingEvents()
+          })
+          .catch(LNbits.utils.notifyApiError)
+      })
     },
     sendEventData() {
       const wallet = _.findWhere(this.g.user.wallets, {
@@ -275,6 +360,8 @@ window.PageEvents = {
     if (this.g.user.wallets.length) {
       this.getTickets()
       this.getEvents()
+      this.getSettings()
+      this.getPendingEvents()
       if (this.g.allowedCurrencies && this.g.allowedCurrencies.length > 0) {
         this.currencies = ['sats', ...this.g.allowedCurrencies]
       } else {

--- a/static/js/index.vue
+++ b/static/js/index.vue
@@ -1,11 +1,85 @@
 <template id="page-events">
   <div class="row q-col-gutter-md">
     <div class="col-12 col-md-8 col-lg-7 q-gutter-y-md">
+      <q-card v-if="isAdmin">
+        <q-card-section>
+          <div class="row items-center justify-between">
+            <div class="col">
+              <span class="text-subtitle1">Settings</span>
+            </div>
+            <div class="col-auto">
+              <q-toggle
+                v-model="settings.auto_approve"
+                label="Auto-approve events"
+                @update:model-value="saveSettings"
+              ></q-toggle>
+            </div>
+          </div>
+        </q-card-section>
+      </q-card>
+
       <q-card>
         <q-card-section>
           <q-btn unelevated color="primary" @click="openEventDialog"
             >New Event</q-btn
           >
+        </q-card-section>
+      </q-card>
+
+      <q-card v-if="pendingEvents.length > 0">
+        <q-card-section>
+          <div class="row items-center no-wrap q-mb-md">
+            <div class="col">
+              <h5 class="text-subtitle1 q-my-none">
+                <q-icon name="pending" color="orange" class="q-mr-sm"></q-icon>
+                Pending Approvals
+                <q-badge
+                  color="orange"
+                  :label="pendingEvents.length"
+                  class="q-ml-sm"
+                ></q-badge>
+              </h5>
+            </div>
+          </div>
+          <q-list separator>
+            <q-item v-for="event in pendingEvents" :key="event.id">
+              <q-item-section>
+                <q-item-label v-text="event.name"></q-item-label>
+                <q-item-label caption>
+                  <span v-text="event.event_start_date"></span>
+                  &mdash;
+                  <span v-text="event.info.substring(0, 80)"></span
+                  ><span v-if="event.info.length > 80">...</span>
+                </q-item-label>
+                <q-item-label caption>
+                  <span v-text="event.amount_tickets"></span> tickets &bull;
+                  <span v-text="event.price_per_ticket"></span>
+                  <span v-text="event.currency"></span>
+                </q-item-label>
+              </q-item-section>
+              <q-item-section side>
+                <div class="row q-gutter-sm">
+                  <q-btn
+                    dense
+                    color="green"
+                    icon="check_circle"
+                    label="Approve"
+                    size="sm"
+                    @click="approveEvent(event.id)"
+                  ></q-btn>
+                  <q-btn
+                    dense
+                    outline
+                    color="red"
+                    icon="block"
+                    label="Reject"
+                    size="sm"
+                    @click="rejectEvent(event.id)"
+                  ></q-btn>
+                </div>
+              </q-item-section>
+            </q-item>
+          </q-list>
         </q-card-section>
       </q-card>
 
@@ -76,6 +150,28 @@
                 </q-td>
                 <q-td auto-width>
                   <q-btn
+                    v-if="isAdmin && props.row.status === 'proposed'"
+                    flat
+                    dense
+                    size="xs"
+                    @click="approveEvent(props.row.id)"
+                    icon="check_circle"
+                    color="green"
+                  >
+                    <q-tooltip>Approve</q-tooltip>
+                  </q-btn>
+                  <q-btn
+                    v-if="isAdmin && props.row.status === 'proposed'"
+                    flat
+                    dense
+                    size="xs"
+                    @click="rejectEvent(props.row.id)"
+                    icon="block"
+                    color="red"
+                  >
+                    <q-tooltip>Reject</q-tooltip>
+                  </q-btn>
+                  <q-btn
                     flat
                     dense
                     size="xs"
@@ -94,7 +190,12 @@
                   ></q-btn>
                 </q-td>
                 <q-td v-for="col in props.cols" :key="col.name" :props="props">
-                  <span v-text="col.value"></span>
+                  <q-badge
+                    v-if="col.name === 'status'"
+                    :color="col.value === 'approved' ? 'green' : col.value === 'proposed' ? 'orange' : 'red'"
+                    :label="col.value"
+                  ></q-badge>
+                  <span v-else v-text="col.value"></span>
                 </q-td>
               </q-tr>
               <q-tr v-show="props.expand" :props="props">
@@ -142,6 +243,51 @@
                       </div>
                     </div>
                   </div>
+                </q-td>
+              </q-tr>
+            </template>
+          </q-table>
+        </q-card-section>
+      </q-card>
+
+      <q-card v-if="isAdmin && allUserEvents.length > 0">
+        <q-card-section>
+          <div class="row items-center no-wrap q-mb-md">
+            <div class="col">
+              <h5 class="text-subtitle1 q-my-none">
+                All Users' Events
+                <q-badge
+                  color="blue"
+                  :label="allUserEvents.length"
+                  class="q-ml-sm"
+                ></q-badge>
+              </h5>
+            </div>
+          </div>
+          <q-table
+            dense
+            flat
+            :rows="allUserEvents"
+            row-key="id"
+            :columns="eventsTable.columns"
+            :pagination="{rowsPerPage: 10}"
+          >
+            <template v-slot:header="props">
+              <q-tr :props="props">
+                <q-th v-for="col in props.cols" :key="col.name" :props="props">
+                  <span v-text="col.label"></span>
+                </q-th>
+              </q-tr>
+            </template>
+            <template v-slot:body="props">
+              <q-tr :props="props">
+                <q-td v-for="col in props.cols" :key="col.name" :props="props">
+                  <q-badge
+                    v-if="col.name === 'status'"
+                    :color="col.value === 'approved' ? 'green' : col.value === 'proposed' ? 'orange' : 'red'"
+                    :label="col.value"
+                  ></q-badge>
+                  <span v-else v-text="col.value"></span>
                 </q-td>
               </q-tr>
             </template>

--- a/static/js/index.vue
+++ b/static/js/index.vue
@@ -192,7 +192,13 @@
                 <q-td v-for="col in props.cols" :key="col.name" :props="props">
                   <q-badge
                     v-if="col.name === 'status'"
-                    :color="col.value === 'approved' ? 'green' : col.value === 'proposed' ? 'orange' : 'red'"
+                    :color="
+                      col.value === 'approved'
+                        ? 'green'
+                        : col.value === 'proposed'
+                          ? 'orange'
+                          : 'red'
+                    "
                     :label="col.value"
                   ></q-badge>
                   <span v-else v-text="col.value"></span>
@@ -284,7 +290,13 @@
                 <q-td v-for="col in props.cols" :key="col.name" :props="props">
                   <q-badge
                     v-if="col.name === 'status'"
-                    :color="col.value === 'approved' ? 'green' : col.value === 'proposed' ? 'orange' : 'red'"
+                    :color="
+                      col.value === 'approved'
+                        ? 'green'
+                        : col.value === 'proposed'
+                          ? 'orange'
+                          : 'red'
+                    "
                     :label="col.value"
                   ></q-badge>
                   <span v-else v-text="col.value"></span>

--- a/views_api.py
+++ b/views_api.py
@@ -139,9 +139,7 @@ async def api_get_event(event_id: str) -> Event:
 
     # closing_date is filled in by create_event (defaults to end_date or
     # start_date) but the field is typed Optional, so guard for the typechecker.
-    closing_date = (
-        event.closing_date or event.event_end_date or event.event_start_date
-    )
+    closing_date = event.closing_date or event.event_end_date or event.event_start_date
     is_window_open = datetime.now(timezone.utc) < datetime.strptime(
         closing_date, "%Y-%m-%d"
     ).replace(tzinfo=timezone.utc)
@@ -181,10 +179,7 @@ async def api_event_create(
 
     ext_settings = await get_settings()
     user_id = wallet.wallet.user
-    is_admin = (
-        user_id == settings.super_user
-        or user_id in settings.lnbits_admin_users
-    )
+    is_admin = user_id == settings.super_user or user_id in settings.lnbits_admin_users
     if not is_admin and not ext_settings.auto_approve:
         data.status = "proposed"
 
@@ -208,9 +203,7 @@ async def api_event_update(
             status_code=HTTPStatus.NOT_FOUND, detail="Event does not exist."
         )
     if event.wallet != wallet.wallet.id:
-        raise HTTPException(
-            status_code=HTTPStatus.FORBIDDEN, detail="Not your event."
-        )
+        raise HTTPException(status_code=HTTPStatus.FORBIDDEN, detail="Not your event.")
     for k, v in data.dict().items():
         setattr(event, k, v)
     event = await update_event(event)
@@ -351,9 +344,7 @@ async def api_get_ticket(ticket_id: str) -> Ticket:
 
 
 @tickets_api_router.post("/{event_id}")
-async def api_ticket_create(
-    event_id: str, data: CreateTicket
-) -> TicketPaymentRequest:
+async def api_ticket_create(event_id: str, data: CreateTicket) -> TicketPaymentRequest:
     event = await get_event(event_id)
     if not event:
         raise HTTPException(
@@ -423,9 +414,7 @@ async def _create_named_ticket(
     )
 
 
-async def _create_user_id_ticket(
-    event: Event, user_id: str
-) -> TicketPaymentRequest:
+async def _create_user_id_ticket(event: Event, user_id: str) -> TicketPaymentRequest:
     price = event.price_per_ticket
     extra: dict[str, Any] = {"tag": "events", "user_id": user_id}
 

--- a/views_api.py
+++ b/views_api.py
@@ -33,6 +33,7 @@ from .crud import (
     get_events,
     get_ticket,
     get_tickets,
+    get_tickets_by_user_id,
     purge_unpaid_tickets,
     update_event,
     update_ticket,
@@ -177,6 +178,16 @@ async def api_tickets(
     return await get_tickets(wallet_ids)
 
 
+@tickets_api_router.get("/user/{user_id}")
+async def api_tickets_by_user_id(user_id: str) -> list[Ticket]:
+    """Tickets bound to an LNbits user_id (used by external integrations).
+
+    Declared before /{ticket_id} so FastAPI matches the literal `/user/`
+    prefix instead of treating "user" as a ticket id.
+    """
+    return await get_tickets_by_user_id(user_id)
+
+
 @tickets_api_router.get("/{ticket_id}", response_model=PublicTicket)
 async def api_get_ticket(ticket_id: str) -> Ticket:
     ticket = await get_ticket(ticket_id)
@@ -193,7 +204,9 @@ async def api_get_ticket(ticket_id: str) -> Ticket:
 
 
 @tickets_api_router.post("/{event_id}")
-async def api_ticket_create(event_id: str, data: CreateTicket) -> TicketPaymentRequest:
+async def api_ticket_create(
+    event_id: str, data: CreateTicket
+) -> TicketPaymentRequest:
     event = await get_event(event_id)
     if not event:
         raise HTTPException(
@@ -206,6 +219,14 @@ async def api_ticket_create(event_id: str, data: CreateTicket) -> TicketPaymentR
     if event.amount_tickets > 0 and event.sold >= event.amount_tickets:
         raise HTTPException(status_code=HTTPStatus.GONE, detail="Event is sold out.")
 
+    if data.user_id:
+        return await _create_user_id_ticket(event, data.user_id)
+    return await _create_named_ticket(event, data)
+
+
+async def _create_named_ticket(
+    event: Event, data: CreateTicket
+) -> TicketPaymentRequest:
     name = data.name
     email = data.email
     promo_code = data.promo_code.upper() if data.promo_code else None
@@ -214,12 +235,10 @@ async def api_ticket_create(event_id: str, data: CreateTicket) -> TicketPaymentR
     extra: dict[str, Any] = {"tag": "events", "name": name, "email": email}
 
     if promo_code:
-        # check if promo_code exists in event.extra.promo_codes
         if promo_code not in [pc.code for pc in event.extra.promo_codes]:
             raise HTTPException(
                 status_code=HTTPStatus.BAD_REQUEST, detail="Invalid promo code."
             )
-        # get the promocode
         promo = next(pc for pc in event.extra.promo_codes if pc.code == promo_code)
         extra["promo_code"] = promo.code
         price = event.price_per_ticket * (1 - promo.discount_percent / 100)
@@ -229,13 +248,12 @@ async def api_ticket_create(event_id: str, data: CreateTicket) -> TicketPaymentR
         extra["currency"] = event.currency
         extra["fiatAmount"] = price
         extra["rate"] = await get_fiat_rate_satoshis(event.currency)
-
         price = await fiat_amount_as_satoshis(price, event.currency)
 
     payment = await create_invoice(
         wallet_id=event.wallet,
         amount=price,
-        memo=f"{event_id}",
+        memo=f"{event.id}",
         extra=extra,
     )
     await create_ticket(
@@ -250,7 +268,36 @@ async def api_ticket_create(event_id: str, data: CreateTicket) -> TicketPaymentR
             "sats_paid": int(price),
         },
     )
+    return TicketPaymentRequest(
+        payment_hash=payment.payment_hash, payment_request=payment.bolt11
+    )
 
+
+async def _create_user_id_ticket(
+    event: Event, user_id: str
+) -> TicketPaymentRequest:
+    price = event.price_per_ticket
+    extra: dict[str, Any] = {"tag": "events", "user_id": user_id}
+
+    if event.currency != "sats":
+        price = await fiat_amount_as_satoshis(event.price_per_ticket, event.currency)
+        extra["fiat"] = True
+        extra["currency"] = event.currency
+        extra["fiatAmount"] = event.price_per_ticket
+        extra["rate"] = await get_fiat_rate_satoshis(event.currency)
+
+    payment = await create_invoice(
+        wallet_id=event.wallet,
+        amount=price,
+        memo=f"{event.id}",
+        extra=extra,
+    )
+    await create_ticket(
+        payment_hash=payment.payment_hash,
+        wallet=event.wallet,
+        event=event.id,
+        user_id=user_id,
+    )
     return TicketPaymentRequest(
         payment_hash=payment.payment_hash, payment_request=payment.bolt11
     )

--- a/views_api.py
+++ b/views_api.py
@@ -12,9 +12,10 @@ from fastapi import (
     WebSocketDisconnect,
 )
 from lnbits.core.crud import get_user
-from lnbits.core.models import WalletTypeInfo
+from lnbits.core.models import Account, WalletTypeInfo
 from lnbits.core.services import create_invoice
 from lnbits.decorators import (
+    check_admin,
     require_admin_key,
     require_invoice_key,
 )
@@ -29,19 +30,26 @@ from .crud import (
     delete_event,
     delete_event_tickets,
     delete_ticket,
+    get_all_events,
     get_event,
+    get_event_tickets,
     get_events,
+    get_pending_events,
+    get_public_events,
+    get_settings,
     get_ticket,
     get_tickets,
     get_tickets_by_user_id,
     purge_unpaid_tickets,
     update_event,
+    update_settings,
     update_ticket,
 )
 from .models import (
     CreateEvent,
     CreateTicket,
     Event,
+    EventsSettings,
     PublicEvent,
     PublicTicket,
     Ticket,
@@ -54,31 +62,87 @@ events_api_router = APIRouter(prefix="/api/v1/events")
 tickets_api_router = APIRouter(prefix="/api/v1/tickets")
 
 
+# Literal-prefix routes (/public, /all, /pending, /settings) MUST be declared
+# before any "/{event_id}" route or FastAPI matches them as a path parameter.
+
+
 @events_api_router.get("")
 async def api_events(
     all_wallets: bool = Query(False),
     wallet: WalletTypeInfo = Depends(require_invoice_key),
 ) -> list[Event]:
     wallet_ids = [wallet.wallet.id]
-
     if all_wallets:
         user = await get_user(wallet.wallet.user)
         wallet_ids = user.wallet_ids if user else []
-
     return await get_events(wallet_ids)
+
+
+@events_api_router.get("/public")
+async def api_events_public() -> list[Event]:
+    """Approved, non-canceled events for an anonymous public listing."""
+    return await get_public_events()
+
+
+@events_api_router.get("/all")
+async def api_events_all(
+    admin: Account = Depends(check_admin),
+) -> list[Event]:
+    """All events across all wallets. LNbits admin only."""
+    return await get_all_events()
+
+
+@events_api_router.get("/pending")
+async def api_events_pending(
+    admin: Account = Depends(check_admin),
+) -> list[Event]:
+    """Proposed events awaiting admin approval. LNbits admin only."""
+    return await get_pending_events()
+
+
+@events_api_router.get("/settings")
+async def api_get_settings(
+    admin: Account = Depends(check_admin),
+) -> EventsSettings:
+    return await get_settings()
+
+
+@events_api_router.put("/settings")
+async def api_update_settings(
+    data: EventsSettings,
+    admin: Account = Depends(check_admin),
+) -> EventsSettings:
+    return await update_settings(data)
 
 
 @events_api_router.get("/{event_id}", response_model=PublicEvent)
 async def api_get_event(event_id: str) -> Event:
+    """Public event detail used by display.vue.
+
+    For approved events we run the upstream sold-out / closing-window /
+    conditional gates. For non-approved events (proposed / rejected) we
+    return the trimmed PublicEvent with status set so the SFC can render
+    the pending-approval banner without a separate request.
+    """
     event = await get_event(event_id)
     if not event:
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND, detail="Event does not exist."
         )
+
+    if event.status != "approved":
+        # Proposed/rejected events are not yet ticketable; skip ticket gates.
+        return event
+
     await purge_unpaid_tickets(event_id)
 
+    # closing_date is filled in by create_event (defaults to end_date or
+    # start_date) but the field is typed Optional, so guard for the typechecker.
+    closing_date = (
+        event.closing_date or event.event_end_date or event.event_start_date
+    )
     is_window_open = datetime.now(timezone.utc) < datetime.strptime(
-        event.closing_date, "%Y-%m-%d"
+        closing_date, "%Y-%m-%d"
     ).replace(tzinfo=timezone.utc)
     is_min_tickets_met = (
         event.sold >= event.extra.min_tickets if event.extra.conditional else True
@@ -89,7 +153,6 @@ async def api_get_event(event_id: str) -> Event:
         event.canceled = True
         await update_event(event)
         await refund_tickets(event_id)
-
         raise HTTPException(status_code=HTTPStatus.GONE, detail="Event canceled.")
 
     if not is_window_open:
@@ -101,30 +164,50 @@ async def api_get_event(event_id: str) -> Event:
 
 
 @events_api_router.post("")
-@events_api_router.put("/{event_id}")
 async def api_event_create(
     data: CreateEvent,
-    wallet: WalletTypeInfo = Depends(require_admin_key),
-    event_id: str | None = None,
+    wallet: WalletTypeInfo = Depends(require_invoice_key),
 ) -> Event:
-    if event_id:
-        event = await get_event(event_id)
-        if not event:
-            raise HTTPException(
-                status_code=HTTPStatus.NOT_FOUND, detail="Event does not exist."
-            )
+    """Create a new event.
 
-        if event.wallet != wallet.wallet.id:
-            raise HTTPException(
-                status_code=HTTPStatus.FORBIDDEN, detail="Not your event."
-            )
-        for k, v in data.dict().items():
-            setattr(event, k, v)
-        event = await update_event(event)
-    else:
-        event = await create_event(data)
+    Anyone with a wallet invoice key can submit. Non-LNbits-admins land in
+    `proposed` status unless `auto_approve` is enabled in extension settings.
+    """
+    if not data.wallet:
+        data.wallet = wallet.wallet.id
 
-    return event
+    from lnbits.settings import settings
+
+    ext_settings = await get_settings()
+    user_id = wallet.wallet.user
+    is_admin = (
+        user_id == settings.super_user
+        or user_id in settings.lnbits_admin_users
+    )
+    if not is_admin and not ext_settings.auto_approve:
+        data.status = "proposed"
+
+    return await create_event(data)
+
+
+@events_api_router.put("/{event_id}")
+async def api_event_update(
+    event_id: str,
+    data: CreateEvent,
+    wallet: WalletTypeInfo = Depends(require_admin_key),
+) -> Event:
+    event = await get_event(event_id)
+    if not event:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND, detail="Event does not exist."
+        )
+    if event.wallet != wallet.wallet.id:
+        raise HTTPException(
+            status_code=HTTPStatus.FORBIDDEN, detail="Not your event."
+        )
+    for k, v in data.dict().items():
+        setattr(event, k, v)
+    return await update_event(event)
 
 
 @events_api_router.put("/{event_id}/cancel")
@@ -137,13 +220,11 @@ async def api_event_cancel(
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND, detail="Event does not exist."
         )
-
     if event.wallet != wallet.wallet.id:
         raise HTTPException(status_code=HTTPStatus.FORBIDDEN, detail="Not your event.")
     event.canceled = True
     event = await update_event(event)
     await refund_tickets(event.id)
-
     return event
 
 
@@ -156,12 +237,56 @@ async def api_form_delete(
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND, detail="Event does not exist."
         )
-
     if event.wallet != wallet.wallet.id:
         raise HTTPException(status_code=HTTPStatus.FORBIDDEN, detail="Not your event.")
-
     await delete_event(event_id)
     await delete_event_tickets(event_id)
+
+
+@events_api_router.put("/{event_id}/approve")
+async def api_event_approve(
+    event_id: str,
+    admin: Account = Depends(check_admin),
+) -> Event:
+    event = await get_event(event_id)
+    if not event:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND, detail="Event does not exist."
+        )
+    if event.status != "proposed":
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail=f"Event is already {event.status}.",
+        )
+    event.status = "approved"
+    return await update_event(event)
+
+
+@events_api_router.put("/{event_id}/reject")
+async def api_event_reject(
+    event_id: str,
+    admin: Account = Depends(check_admin),
+) -> Event:
+    event = await get_event(event_id)
+    if not event:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND, detail="Event does not exist."
+        )
+    if event.status != "proposed":
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail=f"Event is already {event.status}.",
+        )
+    event.status = "rejected"
+    return await update_event(event)
+
+
+@events_api_router.get(
+    "/{event_id}/tickets",
+    response_model=list[PublicTicket],
+)
+async def api_event_tickets(event_id: str) -> list[Ticket]:
+    return await get_event_tickets(event_id)
 
 
 @tickets_api_router.get("")
@@ -212,10 +337,13 @@ async def api_ticket_create(
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND, detail="Event does not exist."
         )
-
+    if event.status != "approved":
+        raise HTTPException(
+            status_code=HTTPStatus.GONE,
+            detail="Event is not yet open for tickets.",
+        )
     if event.canceled:
         raise HTTPException(status_code=HTTPStatus.GONE, detail="Event is canceled.")
-
     if event.amount_tickets > 0 and event.sold >= event.amount_tickets:
         raise HTTPException(status_code=HTTPStatus.GONE, detail="Event is sold out.")
 

--- a/views_api.py
+++ b/views_api.py
@@ -55,6 +55,7 @@ from .models import (
     Ticket,
     TicketPaymentRequest,
 )
+from .nostr_hooks import publish_or_delete_nostr_event
 from .services import refund_tickets
 from .tasks import deregister_payment_listener, register_payment_listener
 
@@ -187,7 +188,12 @@ async def api_event_create(
     if not is_admin and not ext_settings.auto_approve:
         data.status = "proposed"
 
-    return await create_event(data)
+    event = await create_event(data)
+
+    if event.status == "approved":
+        await publish_or_delete_nostr_event(event)
+
+    return event
 
 
 @events_api_router.put("/{event_id}")
@@ -207,7 +213,13 @@ async def api_event_update(
         )
     for k, v in data.dict().items():
         setattr(event, k, v)
-    return await update_event(event)
+    event = await update_event(event)
+
+    # Re-publish the replaceable NIP-52 event if we already announced it.
+    if event.status == "approved" and event.nostr_event_id:
+        await publish_or_delete_nostr_event(event)
+
+    return event
 
 
 @events_api_router.put("/{event_id}/cancel")
@@ -225,6 +237,10 @@ async def api_event_cancel(
     event.canceled = True
     event = await update_event(event)
     await refund_tickets(event.id)
+
+    if event.nostr_event_id:
+        await publish_or_delete_nostr_event(event, delete=True)
+
     return event
 
 
@@ -239,6 +255,10 @@ async def api_form_delete(
         )
     if event.wallet != wallet.wallet.id:
         raise HTTPException(status_code=HTTPStatus.FORBIDDEN, detail="Not your event.")
+
+    if event.nostr_event_id:
+        await publish_or_delete_nostr_event(event, delete=True)
+
     await delete_event(event_id)
     await delete_event_tickets(event_id)
 
@@ -259,7 +279,9 @@ async def api_event_approve(
             detail=f"Event is already {event.status}.",
         )
     event.status = "approved"
-    return await update_event(event)
+    event = await update_event(event)
+    await publish_or_delete_nostr_event(event)
+    return event
 
 
 @events_api_router.put("/{event_id}/reject")


### PR DESCRIPTION
## Summary

This PR adds three main features to the events extension, plus several smaller improvements that emerged along the way:

### 1. Event proposal & approval workflow
- New `status` field on Event (`proposed` / `approved` / `rejected`)
- *Non-admin users' events default to `proposed` and require LNbits admin approval 
- Admin-toggleable `auto_approve` setting (e.g. for trusted/demo deployments)
- Admin UI: pending approvals card, "all users' events" view, settings toggle

### 2. NIP-52 calendar event publishing
- Publishes kind 31922 calendar events to Nostr relays via the nostrclient extension on event approval/creation
- Map fields: `title`, `start`, `end`, `image`, `location`, `t` (categories), `d` (event id)
- Republishes on update (replaceable events)
- Publishes kind 5 delete on cancel/delete
- Events signed with the creator's LNbits Account nostr keypair

### 3. Bidirectional Nostr sync
- *Subscribes to kind 31922/31923 from relays and upserts into the local DB
- *Enables federated event discovery

### Misc improvements
- Make `event_end_date`, `closing_date`, `info` optional with sensible defaults
- New optional fields: `location`, `categories`
- Admin-only `/events/all` and `/events/pending` endpoints (uses `check_admin`)
- Consolidated `POST /events` and `POST /events/propose` into a single endpoint

## Dependencies

- `nostrclient` extension must be installed for Nostr sync; if not, the extension still functions normally without Nostr publishing.
- The Account keypair signing assumes accounts have a `prvkey` field (we have this in our LNbits fork). (The Nostr publishing in nostr_hooks.py reads account.prvkey to sign NIP-52 calendar events with the wallet owner's keypair.)


## * Footnote: 

There is a bit of a misleading feature included here... In one respect I have an admin approval feature, however there is nothing stopping someone from just publishing a NIP-52 to the relay. In the context of a community, running this as a service and/or reducing spam, I wonder if I might also sign published events as the admin to indicate "approved" events versus any old nip-52. 

## Other note

Currently there's no nostr component of purchasing tickets like you can do with nostrmarket, but it's planned