### PR TITLE
feat: register public page saves to localstorage

### DIFF
--- a/static/js/register.js
+++ b/static/js/register.js
@@ -5,15 +5,14 @@ window.PageEventsRegister = {
       tickets: [],
       ticketsTable: {
         columns: [
-          {name: 'id', align: 'left', label: 'ID', field: 'id'},
           {name: 'name', align: 'left', label: 'Name', field: 'name'},
           {name: 'email', align: 'left', label: 'Email', field: 'email'},
-          {name: 'paid', align: 'left', label: 'Paid', field: 'paid'},
           {
-            name: 'registered',
+            name: 'id',
             align: 'left',
-            label: 'Registered',
-            field: 'registered'
+            label: 'ID',
+            field: 'id',
+            format: val => this.shortId(val)
           }
         ],
         pagination: {
@@ -43,6 +42,9 @@ window.PageEventsRegister = {
     },
     showCamera() {
       this.sendCamera.show = true
+    },
+    shortId(id) {
+      return id ? `${id.slice(0, 6)}...${id.slice(-4)}` : ''
     },
     decodeQR(res) {
       this.sendCamera.show = false

--- a/static/js/register.js
+++ b/static/js/register.js
@@ -23,7 +23,8 @@ window.PageEventsRegister = {
       sendCamera: {
         show: false,
         camera: 'auto'
-      }
+      },
+      lastScan: null
     }
   },
   methods: {
@@ -50,12 +51,18 @@ window.PageEventsRegister = {
         .request('PUT', `/events/api/v1/tickets/register/${value}`)
         .then(response => {
           this.saveScannedTicket(response.data)
-          Quasar.Notify.create({
-            type: 'positive',
-            message: 'Registered!'
-          })
+          this.lastScan = {success: true, ticket: response.data}
+          Quasar.Notify.create({type: 'positive', message: 'Registered!'})
         })
-        .catch(LNbits.utils.notifyApiError)
+        .catch(error => {
+          this.lastScan = {
+            success: false,
+            ticketId: value,
+            error:
+              error.response?.data?.detail || error.message || 'Unknown error'
+          }
+          LNbits.utils.notifyApiError(error)
+        })
     }
   },
   created() {

--- a/static/js/register.js
+++ b/static/js/register.js
@@ -5,18 +5,15 @@ window.PageEventsRegister = {
       tickets: [],
       ticketsTable: {
         columns: [
+          {name: 'id', align: 'left', label: 'ID', field: 'id'},
           {name: 'name', align: 'left', label: 'Name', field: 'name'},
+          {name: 'email', align: 'left', label: 'Email', field: 'email'},
+          {name: 'paid', align: 'left', label: 'Paid', field: 'paid'},
           {
             name: 'registered',
             align: 'left',
             label: 'Registered',
             field: 'registered'
-          },
-          {
-            name: 'paid',
-            align: 'left',
-            label: 'Paid',
-            field: 'paid'
           }
         ],
         pagination: {
@@ -30,8 +27,15 @@ window.PageEventsRegister = {
     }
   },
   methods: {
-    hoverEmail(tmp) {
-      this.tickets.data.emailtemp = tmp
+    storageKey() {
+      return `events_scanned_${this.eventId}`
+    },
+    loadScannedTickets() {
+      this.tickets = Quasar.LocalStorage.getItem(this.storageKey()) || []
+    },
+    saveScannedTicket(ticket) {
+      this.tickets.unshift(ticket)
+      Quasar.LocalStorage.set(this.storageKey(), this.tickets)
     },
     closeCamera() {
       this.sendCamera.show = false
@@ -44,25 +48,18 @@ window.PageEventsRegister = {
       const value = res[0].rawValue.split('//')[1]
       LNbits.api
         .request('PUT', `/events/api/v1/tickets/register/${value}`)
-        .then(() => {
+        .then(response => {
+          this.saveScannedTicket(response.data)
           Quasar.Notify.create({
             type: 'positive',
             message: 'Registered!'
           })
         })
         .catch(LNbits.utils.notifyApiError)
-    },
-    getEventTickets() {
-      LNbits.api
-        .request('GET', `/events/api/v1/events/${this.eventId}/tickets`)
-        .then(response => {
-          this.tickets = response.data
-        })
-        .catch(LNbits.utils.notifyApiError)
     }
   },
   created() {
     this.eventId = this.$route.params.id
-    this.getEventTickets()
+    this.loadScannedTickets()
   }
 }

--- a/static/js/register.vue
+++ b/static/js/register.vue
@@ -26,11 +26,11 @@
             <div><strong>Name:</strong> {{ lastScan.ticket.name }}</div>
             <div><strong>Email:</strong> {{ lastScan.ticket.email }}</div>
             <div><strong>Paid:</strong> {{ lastScan.ticket.paid }}</div>
-            <div><strong>ID:</strong> {{ lastScan.ticket.id }}</div>
+            <div><strong>ID:</strong> {{ shortId(lastScan.ticket.id) }}</div>
           </div>
           <div v-else>
             <div class="text-h6 q-mb-sm">Failed</div>
-            <div><strong>Ticket ID:</strong> {{ lastScan.ticketId }}</div>
+            <div><strong>Ticket ID:</strong> {{ shortId(lastScan.ticketId) }}</div>
             <div><strong>Error:</strong> {{ lastScan.error }}</div>
           </div>
         </q-card-section>

--- a/static/js/register.vue
+++ b/static/js/register.vue
@@ -16,6 +16,26 @@
         </q-card-section>
       </q-card>
 
+      <q-card
+        v-if="lastScan"
+        :class="lastScan.success ? 'bg-positive' : 'bg-negative'"
+      >
+        <q-card-section class="text-white">
+          <div v-if="lastScan.success">
+            <div class="text-h6 q-mb-sm">Registered</div>
+            <div><strong>Name:</strong> {{ lastScan.ticket.name }}</div>
+            <div><strong>Email:</strong> {{ lastScan.ticket.email }}</div>
+            <div><strong>Paid:</strong> {{ lastScan.ticket.paid }}</div>
+            <div><strong>ID:</strong> {{ lastScan.ticket.id }}</div>
+          </div>
+          <div v-else>
+            <div class="text-h6 q-mb-sm">Failed</div>
+            <div><strong>Ticket ID:</strong> {{ lastScan.ticketId }}</div>
+            <div><strong>Error:</strong> {{ lastScan.error }}</div>
+          </div>
+        </q-card-section>
+      </q-card>
+
       <q-card>
         <q-card-section>
           <q-table

--- a/static/js/register.vue
+++ b/static/js/register.vue
@@ -30,7 +30,9 @@
           </div>
           <div v-else>
             <div class="text-h6 q-mb-sm">Failed</div>
-            <div><strong>Ticket ID:</strong> {{ shortId(lastScan.ticketId) }}</div>
+            <div>
+              <strong>Ticket ID:</strong> {{ shortId(lastScan.ticketId) }}
+            </div>
             <div><strong>Error:</strong> {{ lastScan.error }}</div>
           </div>
         </q-card-section>

--- a/views_api.py
+++ b/views_api.py
@@ -163,7 +163,6 @@ async def api_form_delete(
     await delete_event_tickets(event_id)
 
 
-
 @tickets_api_router.get("")
 async def api_tickets(
     all_wallets: bool = Query(False),

--- a/views_api.py
+++ b/views_api.py
@@ -30,7 +30,6 @@ from .crud import (
     delete_event_tickets,
     delete_ticket,
     get_event,
-    get_event_tickets,
     get_events,
     get_ticket,
     get_tickets,
@@ -163,13 +162,6 @@ async def api_form_delete(
     await delete_event(event_id)
     await delete_event_tickets(event_id)
 
-
-@events_api_router.get(
-    "/{event_id}/tickets",
-    response_model=list[PublicTicket],
-)
-async def api_event_tickets(event_id: str) -> list[Ticket]:
-    return await get_event_tickets(event_id)
 
 
 @tickets_api_router.get("")
@@ -323,7 +315,7 @@ async def api_ticket_delete(
     await delete_ticket(ticket_id)
 
 
-@tickets_api_router.put("/register/{ticket_id}", response_model=PublicTicket)
+@tickets_api_router.put("/register/{ticket_id}")
 async def api_event_register_ticket(ticket_id) -> Ticket:
     ticket = await get_ticket(ticket_id)
 


### PR DESCRIPTION
previsously it fetched all tickets without much information. now it saves the full scanned ticket after it was scanned, so it can be rechecked by some1 without a login.

also adds a preview of the last scanned ticket.

the IDs got shortened later, see error screenshot.

<img width="576" height="1280" alt="photo_2026-05-05_09-31-32" src="https://github.com/user-attachments/assets/d15c767d-54e5-43b8-af55-a79a965cf670" />
<img width="576" height="1280" alt="photo_2026-05-05_09-31-21" src="https://github.com/user-attachments/assets/396053c7-5fd2-45ad-934b-43c0410e43e6" />
